### PR TITLE
Publish plugins to s3://get.pulumi.com, too.

### DIFF
--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -27,20 +27,43 @@ fi
 # Tar up the plugin
 tar -czf ${PLUGIN_PACKAGE_PATH} -C ${WORK_PATH} .
 
-# rel.pulumi.com is in our production account, so assume that role first
-CREDS_JSON=$(aws sts assume-role \
-                 --role-arn "arn:aws:iam::058607598222:role/UploadPulumiReleases" \
-                 --role-session-name "upload-plugin-pulumi-resource-aws" \
+# Store the initial AWS credentials. The AWS creds will get overwritten after
+# calling assume_iam_role, and restored via restore_initial_aws_keys.
+export INITIAL_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+export INITIAL_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+
+restore_initial_aws_keys() {
+    unset {AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_SECURITY_TOKEN}
+    export AWS_ACCESS_KEY_ID="${INITIAL_AWS_ACCESS_KEY_ID}"
+    export AWS_SECRET_ACCESS_KEY="${INITIAL_AWS_SECRET_ACCESS_KEY}"
+}
+
+assume_iam_role() {
+    local CREDS_JSON=$(aws sts assume-role \
+                 --role-arn "${1}" \
+                 --role-session-name "upload-plugin-pulumi-resource-${PROVIDER_NAME}" \
                  --external-id "upload-pulumi-release")
+    export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
+    export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
+    export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
+}
 
-# Use the credentials we just assumed
-export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
-export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
-export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
 
-echo "Uploading ${PLUGIN_PACKAGE_NAME}..."
+echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://rel.pulumi.com..."
 
+assume_iam_role  "arn:aws:iam::058607598222:role/UploadPulumiReleases"
 aws s3 cp --only-show-errors "${PLUGIN_PACKAGE_PATH}" "s3://rel.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
+restore_initial_aws_keys
+
+# Assume the role to publish plugins to s3://get.pulumi.com. We upload the plugins to two buckets while
+# we transition to only publishing/serving them from get.pulumi.com.
+echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://get.pulumi.com..."
+
+assume_iam_role "arn:aws:iam::058607598222:role/PulumiUploadRelease"
+aws s3 cp \
+    --only-show-errors --acl public-read \
+    "${PLUGIN_PACKAGE_PATH}" "s3://get.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
+restore_initial_aws_keys
 
 rm -rf "${PLUGIN_PACKAGE_DIR}"
 rm -rf "${WORK_PATH}"


### PR DESCRIPTION

This PR updates the publish-plugin.sh script to copy built plugins to s3://get.pulumi.com
in addition to s3://rel.pulumi.com. This is so that we can migrate to serving plugins via
CDN on https://get.pulumi.com, instead of https://api.pulumi.com like we do today.

For more information about the overall effort, see [this comment](https://github.com/pulumi/pulumi-service/issues/3068#issuecomment-626878731).

In addition, immediately before this code gets merged, I will also update the AWS access key
used for this repo on:

- Travis CI: https://travis-ci.com/github/pulumi/pulumi-spotinst/settings
- GitHub Actions: https://github.com/pulumi/pulumi-spotinst/settings/secrets (if applicable)

The access key will be fore a different IAM User. This is part of https://github.com/pulumi/home/issues/708,
and managing Pulumi's internal AWS access using Pulumi (and migrating off hand-crafted IAM permissions we
set up in 2017).

> I'm assuming that this repository doesn't need to create AWS resources, so I'll use an access key
> that only has permissions to upload resources and publish plugins but nothing else. I'll discover
> if this is correct when testing out the release path post-merge. (And can update Travis out of band.)

## Next Steps

After this review gets the LGTM, the next steps are:

1. Update the AWS credentials on Travis, GitHub
2. Merge the PR. Wait for master to be green. Fix any problems associated with this PR.
3. Tag master with v2.1.2-beta.1 and push the tags. This will trigger a release of the
   plugin, and wait for green CI/CD to confirm no problems with that either.
4. Celebrate I didn't break anything.