### PR TITLE
Use new configure-aws.sh script for managing AWS keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ before_install:
     - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
+    # Configure the local AWS SDK and use the `pulumi-ci` profile for when
+    # weo run tests later.
+    - source ${PULUMI_SCRIPTS}/ci/configure-aws.sh
+    - export AWS_PROFILE=pulumi-ci
     - curl -L https://get.pulumi.com/ | bash
     - export PATH=$HOME/.pulumi/bin:$PATH
 before_script:

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -27,43 +27,30 @@ fi
 # Tar up the plugin
 tar -czf ${PLUGIN_PACKAGE_PATH} -C ${WORK_PATH} .
 
-# Store the initial AWS credentials. The AWS creds will get overwritten after
-# calling assume_iam_role, and restored via restore_initial_aws_keys.
-export INITIAL_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
-export INITIAL_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
-
-restore_initial_aws_keys() {
-    unset {AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_SECURITY_TOKEN}
-    export AWS_ACCESS_KEY_ID="${INITIAL_AWS_ACCESS_KEY_ID}"
-    export AWS_SECRET_ACCESS_KEY="${INITIAL_AWS_SECRET_ACCESS_KEY}"
-}
-
-assume_iam_role() {
-    local CREDS_JSON=$(aws sts assume-role \
-                 --role-arn "${1}" \
-                 --role-session-name "upload-plugin-pulumi-resource-${PROVIDER_NAME}" \
-                 --external-id "upload-pulumi-release")
-    export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
-    export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
-    export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
-}
-
+# Switch back to the default AWS profile for the duration of this script. Since if we were using
+# another profile, we wouldn't be able to assume the upload roles. (Functions defined in
+# scripts repo in ci/configure-aws.sh, sourced from .travis.yml.)
+unset AWS_PROFILE
 
 echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://rel.pulumi.com..."
-
-assume_iam_role  "arn:aws:iam::058607598222:role/UploadPulumiReleases"
+assume_iam_role \
+     "arn:aws:iam::058607598222:role/UploadPulumiReleases" \
+     "upload-plugin-pulumi-resource-${PROVIDER_NAME}" \
+     "upload-pulumi-release"
 aws s3 cp --only-show-errors "${PLUGIN_PACKAGE_PATH}" "s3://rel.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
-restore_initial_aws_keys
+unassume_iam_role
 
 # Assume the role to publish plugins to s3://get.pulumi.com. We upload the plugins to two buckets while
 # we transition to only publishing/serving them from get.pulumi.com.
 echo "Uploading ${PLUGIN_PACKAGE_NAME} to s3://get.pulumi.com..."
-
-assume_iam_role "arn:aws:iam::058607598222:role/PulumiUploadRelease"
+assume_iam_role \
+     "arn:aws:iam::058607598222:role/PulumiUploadRelease" \
+     "upload-plugin-pulumi-resource-${PROVIDER_NAME}" \
+     "upload-pulumi-release"
 aws s3 cp \
     --only-show-errors --acl public-read \
     "${PLUGIN_PACKAGE_PATH}" "s3://get.pulumi.com/releases/plugins/${PLUGIN_PACKAGE_NAME}"
-restore_initial_aws_keys
+unassume_iam_role
 
 rm -rf "${PLUGIN_PACKAGE_DIR}"
 rm -rf "${WORK_PATH}"


### PR DESCRIPTION
CI for this repo is currently broken because of https://github.com/pulumi/pulumi-spotinst/pull/19. In changing the AWS credentials used, the tests cases now fail because the new IAM User doesn't have access to create AWS resources. Instead, they now need to assume role into the `pulumi-ci` AWS Account.

https://github.com/pulumi/scripts/pull/116 added a new `configure-aws.sh` script to the `pulumi/scripts` repo, and this PR relies on that to set the AWS credentials and use different profiles to make things easier to manage.

🤞 this will fix all known problems and leave the `publish-plugin.sh` script in a slightly cleaner state.