### PR TITLE
Upgrade terraform-provider-spotinst to v1.160.2

### DIFF
--- a/provider/cmd/pulumi-resource-spotinst/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-spotinst/bridge-metadata.json
@@ -2261,7 +2261,15 @@
             }
         }
     },
-    "auto-settings": {},
+    "auto-settings": {
+        "resources": {
+            "spotinst_ocean_aws": {
+                "maxItemsOneOverrides": {
+                    "scheduled_task": false
+                }
+            }
+        }
+    },
     "renames": {
         "resources": {
             "spotinst:aws/account:Account": "spotinst_account_aws",


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-spotinst`.

---

- Upgrading terraform-provider-spotinst from 1.160.1  to 1.160.2.
	Fixes #569
