### PR TITLE
Upgrade terraform-provider-spotinst to v1.193.0

### DIFF
--- a/provider/cmd/pulumi-resource-spotinst/schema.json
+++ b/provider/cmd/pulumi-resource-spotinst/schema.json
@@ -6742,11 +6742,15 @@
                 },
                 "preemptiblePercentage": {
                     "type": "integer",
-                    "description": "Defines the desired preemptible percentage for the cluster.\n\n"
+                    "description": "Defines the desired preemptible percentage for the cluster.\n"
                 },
                 "provisioningModel": {
                     "type": "string",
                     "description": "Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.\n"
+                },
+                "shouldUtilizeCommitments": {
+                    "type": "boolean",
+                    "description": "Enable committed use discounts utilization.\n\n"
                 }
             },
             "type": "object"

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.7
 require (
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.91.0
 	github.com/pulumi/pulumi/sdk/v3 v3.133.0
-	github.com/spotinst/terraform-provider-spotinst v1.192.0
+	github.com/spotinst/terraform-provider-spotinst v1.193.0
 )
 
 replace (
@@ -201,7 +201,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spotinst/spotinst-sdk-go v1.368.0 // indirect
+	github.com/spotinst/spotinst-sdk-go v1.369.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/teekennedy/goldmark-markdown v0.3.0 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2025,10 +2025,10 @@ github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spotinst/spotinst-sdk-go v1.368.0 h1:CV0w6C6EKK3s4R5B+OkAwx2abt7Kx+Qcd5EvrBsCBog=
-github.com/spotinst/spotinst-sdk-go v1.368.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
-github.com/spotinst/terraform-provider-spotinst v1.192.0 h1:jyfcQAjTS55Oipwg3z/zmgGf+RkT8w8B8vzhCnqAM0M=
-github.com/spotinst/terraform-provider-spotinst v1.192.0/go.mod h1:Ux6IpfJ7JdKFOqz/QIZiQiBKxERMk2JD89+6gH4nk5Y=
+github.com/spotinst/spotinst-sdk-go v1.369.0 h1:E/39f8GV5FZk4goFBQT8e1O6YUDfn2DVOGCLK5yM16k=
+github.com/spotinst/spotinst-sdk-go v1.369.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
+github.com/spotinst/terraform-provider-spotinst v1.193.0 h1:KJz53sNH5G2//q0YK/ZGkdZqBqjvWUhs53KhD0TS1RA=
+github.com/spotinst/terraform-provider-spotinst v1.193.0/go.mod h1:vA73/HWLdaLo9qfxzG20A7uquKx+hRkDkaV7YXJ0yz0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/sdk/dotnet/Gke/Inputs/OceanImportStrategyArgs.cs
+++ b/sdk/dotnet/Gke/Inputs/OceanImportStrategyArgs.cs
@@ -30,6 +30,12 @@ namespace Pulumi.SpotInst.Gke.Inputs
         [Input("provisioningModel")]
         public Input<string>? ProvisioningModel { get; set; }
 
+        /// <summary>
+        /// Enable committed use discounts utilization.
+        /// </summary>
+        [Input("shouldUtilizeCommitments")]
+        public Input<bool>? ShouldUtilizeCommitments { get; set; }
+
         public OceanImportStrategyArgs()
         {
         }

--- a/sdk/dotnet/Gke/Inputs/OceanImportStrategyGetArgs.cs
+++ b/sdk/dotnet/Gke/Inputs/OceanImportStrategyGetArgs.cs
@@ -30,6 +30,12 @@ namespace Pulumi.SpotInst.Gke.Inputs
         [Input("provisioningModel")]
         public Input<string>? ProvisioningModel { get; set; }
 
+        /// <summary>
+        /// Enable committed use discounts utilization.
+        /// </summary>
+        [Input("shouldUtilizeCommitments")]
+        public Input<bool>? ShouldUtilizeCommitments { get; set; }
+
         public OceanImportStrategyGetArgs()
         {
         }

--- a/sdk/dotnet/Gke/Outputs/OceanImportStrategy.cs
+++ b/sdk/dotnet/Gke/Outputs/OceanImportStrategy.cs
@@ -25,6 +25,10 @@ namespace Pulumi.SpotInst.Gke.Outputs
         /// Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
         /// </summary>
         public readonly string? ProvisioningModel;
+        /// <summary>
+        /// Enable committed use discounts utilization.
+        /// </summary>
+        public readonly bool? ShouldUtilizeCommitments;
 
         [OutputConstructor]
         private OceanImportStrategy(
@@ -32,11 +36,14 @@ namespace Pulumi.SpotInst.Gke.Outputs
 
             int? preemptiblePercentage,
 
-            string? provisioningModel)
+            string? provisioningModel,
+
+            bool? shouldUtilizeCommitments)
         {
             DrainingTimeout = drainingTimeout;
             PreemptiblePercentage = preemptiblePercentage;
             ProvisioningModel = provisioningModel;
+            ShouldUtilizeCommitments = shouldUtilizeCommitments;
         }
     }
 }

--- a/sdk/go/spotinst/gke/pulumiTypes.go
+++ b/sdk/go/spotinst/gke/pulumiTypes.go
@@ -4551,6 +4551,8 @@ type OceanImportStrategy struct {
 	PreemptiblePercentage *int `pulumi:"preemptiblePercentage"`
 	// Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
 	ProvisioningModel *string `pulumi:"provisioningModel"`
+	// Enable committed use discounts utilization.
+	ShouldUtilizeCommitments *bool `pulumi:"shouldUtilizeCommitments"`
 }
 
 // OceanImportStrategyInput is an input type that accepts OceanImportStrategyArgs and OceanImportStrategyOutput values.
@@ -4571,6 +4573,8 @@ type OceanImportStrategyArgs struct {
 	PreemptiblePercentage pulumi.IntPtrInput `pulumi:"preemptiblePercentage"`
 	// Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
 	ProvisioningModel pulumi.StringPtrInput `pulumi:"provisioningModel"`
+	// Enable committed use discounts utilization.
+	ShouldUtilizeCommitments pulumi.BoolPtrInput `pulumi:"shouldUtilizeCommitments"`
 }
 
 func (OceanImportStrategyArgs) ElementType() reflect.Type {
@@ -4637,6 +4641,11 @@ func (o OceanImportStrategyOutput) PreemptiblePercentage() pulumi.IntPtrOutput {
 // Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
 func (o OceanImportStrategyOutput) ProvisioningModel() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v OceanImportStrategy) *string { return v.ProvisioningModel }).(pulumi.StringPtrOutput)
+}
+
+// Enable committed use discounts utilization.
+func (o OceanImportStrategyOutput) ShouldUtilizeCommitments() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v OceanImportStrategy) *bool { return v.ShouldUtilizeCommitments }).(pulumi.BoolPtrOutput)
 }
 
 type OceanImportStrategyArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/spotinst/gke/inputs/OceanImportStrategyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/spotinst/gke/inputs/OceanImportStrategyArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.spotinst.gke.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
@@ -61,12 +62,28 @@ public final class OceanImportStrategyArgs extends com.pulumi.resources.Resource
         return Optional.ofNullable(this.provisioningModel);
     }
 
+    /**
+     * Enable committed use discounts utilization.
+     * 
+     */
+    @Import(name="shouldUtilizeCommitments")
+    private @Nullable Output<Boolean> shouldUtilizeCommitments;
+
+    /**
+     * @return Enable committed use discounts utilization.
+     * 
+     */
+    public Optional<Output<Boolean>> shouldUtilizeCommitments() {
+        return Optional.ofNullable(this.shouldUtilizeCommitments);
+    }
+
     private OceanImportStrategyArgs() {}
 
     private OceanImportStrategyArgs(OceanImportStrategyArgs $) {
         this.drainingTimeout = $.drainingTimeout;
         this.preemptiblePercentage = $.preemptiblePercentage;
         this.provisioningModel = $.provisioningModel;
+        this.shouldUtilizeCommitments = $.shouldUtilizeCommitments;
     }
 
     public static Builder builder() {
@@ -148,6 +165,27 @@ public final class OceanImportStrategyArgs extends com.pulumi.resources.Resource
          */
         public Builder provisioningModel(String provisioningModel) {
             return provisioningModel(Output.of(provisioningModel));
+        }
+
+        /**
+         * @param shouldUtilizeCommitments Enable committed use discounts utilization.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder shouldUtilizeCommitments(@Nullable Output<Boolean> shouldUtilizeCommitments) {
+            $.shouldUtilizeCommitments = shouldUtilizeCommitments;
+            return this;
+        }
+
+        /**
+         * @param shouldUtilizeCommitments Enable committed use discounts utilization.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder shouldUtilizeCommitments(Boolean shouldUtilizeCommitments) {
+            return shouldUtilizeCommitments(Output.of(shouldUtilizeCommitments));
         }
 
         public OceanImportStrategyArgs build() {

--- a/sdk/java/src/main/java/com/pulumi/spotinst/gke/outputs/OceanImportStrategy.java
+++ b/sdk/java/src/main/java/com/pulumi/spotinst/gke/outputs/OceanImportStrategy.java
@@ -4,6 +4,7 @@
 package com.pulumi.spotinst.gke.outputs;
 
 import com.pulumi.core.annotations.CustomType;
+import java.lang.Boolean;
 import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
@@ -27,6 +28,11 @@ public final class OceanImportStrategy {
      * 
      */
     private @Nullable String provisioningModel;
+    /**
+     * @return Enable committed use discounts utilization.
+     * 
+     */
+    private @Nullable Boolean shouldUtilizeCommitments;
 
     private OceanImportStrategy() {}
     /**
@@ -50,6 +56,13 @@ public final class OceanImportStrategy {
     public Optional<String> provisioningModel() {
         return Optional.ofNullable(this.provisioningModel);
     }
+    /**
+     * @return Enable committed use discounts utilization.
+     * 
+     */
+    public Optional<Boolean> shouldUtilizeCommitments() {
+        return Optional.ofNullable(this.shouldUtilizeCommitments);
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -63,12 +76,14 @@ public final class OceanImportStrategy {
         private @Nullable Integer drainingTimeout;
         private @Nullable Integer preemptiblePercentage;
         private @Nullable String provisioningModel;
+        private @Nullable Boolean shouldUtilizeCommitments;
         public Builder() {}
         public Builder(OceanImportStrategy defaults) {
     	      Objects.requireNonNull(defaults);
     	      this.drainingTimeout = defaults.drainingTimeout;
     	      this.preemptiblePercentage = defaults.preemptiblePercentage;
     	      this.provisioningModel = defaults.provisioningModel;
+    	      this.shouldUtilizeCommitments = defaults.shouldUtilizeCommitments;
         }
 
         @CustomType.Setter
@@ -89,11 +104,18 @@ public final class OceanImportStrategy {
             this.provisioningModel = provisioningModel;
             return this;
         }
+        @CustomType.Setter
+        public Builder shouldUtilizeCommitments(@Nullable Boolean shouldUtilizeCommitments) {
+
+            this.shouldUtilizeCommitments = shouldUtilizeCommitments;
+            return this;
+        }
         public OceanImportStrategy build() {
             final var _resultValue = new OceanImportStrategy();
             _resultValue.drainingTimeout = drainingTimeout;
             _resultValue.preemptiblePercentage = preemptiblePercentage;
             _resultValue.provisioningModel = provisioningModel;
+            _resultValue.shouldUtilizeCommitments = shouldUtilizeCommitments;
             return _resultValue;
         }
     }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -4723,6 +4723,10 @@ export namespace gke {
          * Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
          */
         provisioningModel?: pulumi.Input<string>;
+        /**
+         * Enable committed use discounts utilization.
+         */
+        shouldUtilizeCommitments?: pulumi.Input<boolean>;
     }
 
     export interface OceanImportUpdatePolicy {

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -4728,6 +4728,10 @@ export namespace gke {
          * Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
          */
         provisioningModel?: string;
+        /**
+         * Enable committed use discounts utilization.
+         */
+        shouldUtilizeCommitments?: boolean;
     }
 
     export interface OceanImportUpdatePolicy {

--- a/sdk/python/pulumi_spotinst/gke/_inputs.py
+++ b/sdk/python/pulumi_spotinst/gke/_inputs.py
@@ -1852,11 +1852,13 @@ class OceanImportStrategyArgs:
     def __init__(__self__, *,
                  draining_timeout: Optional[pulumi.Input[int]] = None,
                  preemptible_percentage: Optional[pulumi.Input[int]] = None,
-                 provisioning_model: Optional[pulumi.Input[str]] = None):
+                 provisioning_model: Optional[pulumi.Input[str]] = None,
+                 should_utilize_commitments: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[int] draining_timeout: The draining timeout (in seconds) before terminating the instance. If no draining timeout is defined, the default draining timeout will be used.
         :param pulumi.Input[int] preemptible_percentage: Defines the desired preemptible percentage for the cluster.
         :param pulumi.Input[str] provisioning_model: Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
+        :param pulumi.Input[bool] should_utilize_commitments: Enable committed use discounts utilization.
         """
         if draining_timeout is not None:
             pulumi.set(__self__, "draining_timeout", draining_timeout)
@@ -1864,6 +1866,8 @@ class OceanImportStrategyArgs:
             pulumi.set(__self__, "preemptible_percentage", preemptible_percentage)
         if provisioning_model is not None:
             pulumi.set(__self__, "provisioning_model", provisioning_model)
+        if should_utilize_commitments is not None:
+            pulumi.set(__self__, "should_utilize_commitments", should_utilize_commitments)
 
     @property
     @pulumi.getter(name="drainingTimeout")
@@ -1900,6 +1904,18 @@ class OceanImportStrategyArgs:
     @provisioning_model.setter
     def provisioning_model(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "provisioning_model", value)
+
+    @property
+    @pulumi.getter(name="shouldUtilizeCommitments")
+    def should_utilize_commitments(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enable committed use discounts utilization.
+        """
+        return pulumi.get(self, "should_utilize_commitments")
+
+    @should_utilize_commitments.setter
+    def should_utilize_commitments(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "should_utilize_commitments", value)
 
 
 @pulumi.input_type

--- a/sdk/python/pulumi_spotinst/gke/outputs.py
+++ b/sdk/python/pulumi_spotinst/gke/outputs.py
@@ -1875,6 +1875,8 @@ class OceanImportStrategy(dict):
             suggest = "preemptible_percentage"
         elif key == "provisioningModel":
             suggest = "provisioning_model"
+        elif key == "shouldUtilizeCommitments":
+            suggest = "should_utilize_commitments"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in OceanImportStrategy. Access the value via the '{suggest}' property getter instead.")
@@ -1890,11 +1892,13 @@ class OceanImportStrategy(dict):
     def __init__(__self__, *,
                  draining_timeout: Optional[int] = None,
                  preemptible_percentage: Optional[int] = None,
-                 provisioning_model: Optional[str] = None):
+                 provisioning_model: Optional[str] = None,
+                 should_utilize_commitments: Optional[bool] = None):
         """
         :param int draining_timeout: The draining timeout (in seconds) before terminating the instance. If no draining timeout is defined, the default draining timeout will be used.
         :param int preemptible_percentage: Defines the desired preemptible percentage for the cluster.
         :param str provisioning_model: Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
+        :param bool should_utilize_commitments: Enable committed use discounts utilization.
         """
         if draining_timeout is not None:
             pulumi.set(__self__, "draining_timeout", draining_timeout)
@@ -1902,6 +1906,8 @@ class OceanImportStrategy(dict):
             pulumi.set(__self__, "preemptible_percentage", preemptible_percentage)
         if provisioning_model is not None:
             pulumi.set(__self__, "provisioning_model", provisioning_model)
+        if should_utilize_commitments is not None:
+            pulumi.set(__self__, "should_utilize_commitments", should_utilize_commitments)
 
     @property
     @pulumi.getter(name="drainingTimeout")
@@ -1926,6 +1932,14 @@ class OceanImportStrategy(dict):
         Define the provisioning model of the launched instances. Valid values: `SPOT`, `PREEMPTIBLE`.
         """
         return pulumi.get(self, "provisioning_model")
+
+    @property
+    @pulumi.getter(name="shouldUtilizeCommitments")
+    def should_utilize_commitments(self) -> Optional[bool]:
+        """
+        Enable committed use discounts utilization.
+        """
+        return pulumi.get(self, "should_utilize_commitments")
 
 
 @pulumi.output_type


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi/pulumi-spotinst`.

---

- Upgrading terraform-provider-spotinst from 1.192.0  to 1.193.0.
	Fixes #836
